### PR TITLE
Memory leak removed

### DIFF
--- a/CombineExamples/Timer/Timer.storyboard
+++ b/CombineExamples/Timer/Timer.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14810.12" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hHC-vJ-IO1">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hHC-vJ-IO1">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14766.15"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -21,7 +23,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lec-ky-f8y">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lec-ky-f8y">
                                 <rect key="frame" x="191.5" y="205" width="31" height="30"/>
                                 <state key="normal" title="Split"/>
                                 <connections>
@@ -30,10 +32,21 @@
                             </button>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="J7f-U6-Yg9">
                                 <rect key="frame" x="0.0" y="255" width="414" height="607"/>
-                                <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" id="xcA-10-sFI">
+                                        <rect key="frame" x="0.0" y="24.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xcA-10-sFI" id="hkY-w9-njN">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="JeN-E8-kRR"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="JeN-E8-kRR" firstAttribute="bottom" secondItem="J7f-U6-Yg9" secondAttribute="bottom" id="1fp-ON-TcO"/>
                             <constraint firstItem="Lec-ky-f8y" firstAttribute="top" secondItem="zun-Sn-sY3" secondAttribute="bottom" constant="20" id="3B7-3h-UgV"/>
@@ -45,7 +58,6 @@
                             <constraint firstItem="JeN-E8-kRR" firstAttribute="trailing" secondItem="J7f-U6-Yg9" secondAttribute="trailing" id="tba-ZV-11K"/>
                             <constraint firstItem="zun-Sn-sY3" firstAttribute="top" secondItem="JeN-E8-kRR" secondAttribute="top" constant="100" id="yX5-Kl-vIA"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="JeN-E8-kRR"/>
                     </view>
                     <connections>
                         <outlet property="tableView" destination="J7f-U6-Yg9" id="9l8-Tq-b9y"/>
@@ -57,4 +69,9 @@
             <point key="canvasLocation" x="139" y="129"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/CombineExamples/Timer/TimerViewController.swift
+++ b/CombineExamples/Timer/TimerViewController.swift
@@ -14,50 +14,44 @@ class TimerViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView! {
         didSet { tableView.dataSource = self }
     }
-    
-    @Published private var currentTime: String = ""
-    private var laps = [String]()
+
+    private var laps = [String]() {
+      didSet{
+        tableView.reloadData()
+      }
+    }
+
     private var cancellableBag = Set<AnyCancellable>()
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         Timer.publish(every: 0.1, on: .main, in: .default)
-            .autoconnect()
-            .scan(0, { (acc, _ ) in return acc + 1 })
-            .map { $0.timeInterval }
-            .replaceError(with: "")
-            .eraseToAnyPublisher()
-            .assign(to: \.currentTime, on: self)
-            .store(in: &cancellableBag)
-        
-        $currentTime
-            .sink { value in
-                self.timerLabel.text = value
+          .autoconnect()
+          .scan(0, { (acc, _ ) in return acc + 1 })
+          .map { $0.timeInterval }
+          .replaceError(with: nil)
+          .assign(to: \.text, on: timerLabel)
+          .store(in: &cancellableBag)
+
+        splitButtonTaps
+          .map { [weak self] _ -> AnyPublisher<String, Never> in
+            guard let currentTime = self?.timerLabel.text else {
+              return Empty().eraseToAnyPublisher()
             }
-            .store(in: &cancellableBag)
-        
-       splitButtonTaps
-            .map { [weak self] _ -> AnyPublisher<String, Never> in
-                guard let strongSelf = self else {
-                    return Empty().eraseToAnyPublisher()
-                }
-                return Just(strongSelf.currentTime)
-                    .eraseToAnyPublisher()
-            }
-            .switchToLatest()
-            .scan([String]()) { (acc, new) -> [String] in
-                return acc + [new]
-            }
-            .eraseToAnyPublisher()
-            .sink { [weak self] laps in
-                guard let strongSelf = self else { return }
-                strongSelf.laps = laps
-                strongSelf.tableView.reloadData()
-            }
-            .store(in: &cancellableBag)
+            return Just(currentTime)
+              .eraseToAnyPublisher()
+          }
+          .switchToLatest()
+          .scan([String]()) { (acc, new) -> [String] in
+            return acc + [new]
+          }
+          .sink { [weak self] laps in
+            self?.laps = laps
+          }
+          .store(in: &cancellableBag)
     }
-    
+
     private let splitButtonTaps = PassthroughSubject<Void, Never>()
     @IBAction func splitButtonDidTap(_ sender: UIButton) {
         splitButtonTaps.send()
@@ -70,9 +64,7 @@ extension TimerViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell =  tableView.dequeueReusableCell(withIdentifier: "cell") else {
-            return UITableViewCell(style: .default, reuseIdentifier: "cell")
-        }
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
         cell.textLabel?.text = laps[indexPath.row]
         return cell
     }


### PR DESCRIPTION
1. `@Published private var currentTime` removed
2. irrelevant `eraseToPublishers` removed
3. TableView cell managed properly to avoid glitches in UI
4. `didSet` implemented for `laps`
5. `strongSelf` -> `self` rename

tested with memory graph tool built-in Xcode.